### PR TITLE
Rewrite query for latest features

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ibm-data-engine"
-version = "0.2.1"
+version = "0.2.2"
 description = "Feast offline feature store implementation backed by the IBM Cloud Data Engine"
 license = "Apache-2.0"
 authors = [

--- a/tests/data/registry.db
+++ b/tests/data/registry.db
@@ -1,8 +1,8 @@
 
-@
+>
  
-driver"	driver_idJtest_plugin
-ìó«¸îµ¯ìó«¸îµ¯1"$d3da61b1-34bb-4c74-ae14-217b9798805b*ìó«¸Øæ¯2Ù
+driver"	driver_idJtest_plugin
+—Î±¬€êÔq—Î±¬€êÔq1"$18affa2d-605b-46d3-86d7-1dcee5793226*—Î±¬ø¡ßq2Ù
 ¸
 driver_hourly_statstest_plugindriver"
 	conv_rate"

--- a/tests/test_ibm_data_engine.py
+++ b/tests/test_ibm_data_engine.py
@@ -352,7 +352,7 @@ class TestDataEngineOfflineStore:
             ),
         )
         assert_frame_equal(job.to_df(), df)
-        expected_arg = "SELECT de_a.docid, de_a.source, de_a.timestamp FROM `document_features` as de_a JOIN (SELECT docid,\n       max(timestamp) AS timestamp\nFROM document_features\nWHERE timestamp BETWEEN cast('2022-08-12 09:09:27.108650' AS TIMESTAMP) AND cast('2022-08-12 09:09:27.108652' AS TIMESTAMP)\nGROUP BY docid) as de_b WHERE de_a.docid = de_b.docid AND de_a.timestamp = de_b.timestamp"
+        expected_arg = "SELECT de_a.docid, de_a.source, de_a.timestamp FROM (SELECT docid,\n       SOURCE, timestamp\nFROM document_features\nWHERE timestamp BETWEEN cast('2022-08-12 09:09:27.108650' AS TIMESTAMP) AND cast('2022-08-12 09:09:27.108652' AS TIMESTAMP)) as de_a JOIN (SELECT docid,\n       max(timestamp) AS timestamp\nFROM document_features\nWHERE timestamp BETWEEN cast('2022-08-12 09:09:27.108650' AS TIMESTAMP) AND cast('2022-08-12 09:09:27.108652' AS TIMESTAMP)\nGROUP BY docid) as de_b USING (docid, timestamp)"
         sql.run_sql.assert_called_once_with(expected_arg)
 
     def test_get_historical_features(self, monkeypatch):


### PR DESCRIPTION
The old query used one subquery that calculated max timestamp in a range. The new query introduces an additional subquery that limits the joined data to the range we want, and the join is performed on the results of those two subqueries.

This is more efficient in presence of a metaindex on the timestamp column, because it may significantly reduces the number of objects that need to be read.